### PR TITLE
Fix for PHP warning: Non static method called staticly

### DIFF
--- a/models/flowplayer-frontend.php
+++ b/models/flowplayer-frontend.php
@@ -490,7 +490,7 @@ class flowplayer_frontend extends flowplayer
 					}  
 					
 					if (isset($aSubtitles) && !empty($aSubtitles)) {
-            $aLangs = $this->get_languages();
+            $aLangs = self::get_languages();
             $countSubtitles = 0;
             foreach( $aSubtitles AS $key => $subtitles ) {
               if( $key == 'subtitles' ) {                   

--- a/models/flowplayer.php
+++ b/models/flowplayer.php
@@ -867,7 +867,7 @@ class flowplayer extends FV_Wordpress_Flowplayer_Plugin {
   }
   
   
-  function get_languages() {
+  public static function get_languages() {
     $aLangs = array(
       'AB' => 'Abkhazian',
       'AA' => 'Afar',


### PR DESCRIPTION
-changing get_languages() to public static
-editing another call to this function form "this->" to "self::"